### PR TITLE
issue_second-2:[チーム情報の操作に関しての機能を整えること] 追加版

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,4 +16,7 @@ class ApplicationController < ActionController::Base
   def init_team
     current_user.assigns.create!(team_id: Team.first.id) if current_user.teams.blank?
   end
+
+  protect_from_forgery with: :exception
+  include ApplicationHelper
 end

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -30,18 +30,20 @@ class AssignsController < ApplicationController
       'リーダーは削除できません。'
     elsif Assign.where(user_id: assigned_user.id).count == 1
       'このユーザーはこのチームにしか所属していないため、削除できません。'
+    elsif ( current_user.id != assign.team.owner.id ) && ( current_user.id != assigned_user.id )
+      'リーダー以外のメンバーは、自分以外のユーザーは削除できません。'
     elsif assign.destroy
       set_next_team(assign, assigned_user)
       'メンバーを削除しました。'
     else
       'なんらかの原因で、削除できませんでした。'
-    end    
-  end  
-  
+    end
+  end
+
   def email_reliable?(address)
     address.match(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i)
   end
-  
+
   def set_next_team(assign, assigned_user)
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,11 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  # def edit; end
+def edit
+  puts "*****************************"
+  return
+end
 
   def create
     @team = Team.new(team_params)

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -16,10 +16,11 @@ class TeamsController < ApplicationController
   end
 
   # def edit; end
-def edit
-  puts "*****************************"
-  return
-end
+  def edit
+    if @team.owner.id != current_user.id
+      redirect_to team_url, notice: 'チームリーダー以外はチーム情報を編集することができません。'
+    end
+  end
 
   def create
     @team = Team.new(team_params)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,6 +4,7 @@ class Users::SessionsController < Devise::SessionsController
   private
 
   def after_sign_in_path_for(user)
+    session[:user_id] = user.id
     keep_team = user.keep_team_id
     if keep_team.nil?
       if user.teams.count == 1

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,4 +23,7 @@ module ApplicationHelper
       article_path(article)
     end
   end
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
+  end
 end

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to 'チーム情報を編集する', edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% if @team.owner.id == current_user.id %>
+              <%= link_to 'チーム情報を編集する', edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>
           </div>
 
           <div class="col-md-8">
@@ -41,7 +43,15 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <td>
+                        <% if (
+                                ( current_user.id == assign.team.owner.id ) && ( current_user.id != assign.user.id ) ||
+                                ( current_user.id != assign.team.owner.id ) && ( current_user.id == assign.user.id )
+                              )
+                        %>
+                          <%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %>
+                        <% end %>
+                      </td>
                     </tr>
                   <% end %>
                 </tbody>


### PR DESCRIPTION
1.Teamに所属しているUserの削除は、そのTeamのオーナーか、そのUser自身しかできないようにする
2.TeamのeditはTeamのリーダー（オーナー）のみができるようにする
3.Team編集画面での編集ボタン、削除ボタンの表示制御追加